### PR TITLE
Don't inherit FDs when Popening sass.

### DIFF
--- a/civet/asset_precompiler.py
+++ b/civet/asset_precompiler.py
@@ -259,7 +259,7 @@ def precompile_sass(sass_files, watch=False):
     args = ['sass', '--watch']
     args.extend(sass_arguments)
     args.extend(dir_pairs)
-    process = subprocess.Popen(args)
+    process = subprocess.Popen(args, close_fds=True)
 
     # Django's autoreload calls sys.exit() before reloading, and we want to
     # kill the Sass process we've spawned at that point.


### PR DESCRIPTION
When runserver launches sass, it uses Popen, which, by default, inherits the file descriptors of the parent process.  This will include the listen socket used by runserver to accept web connections.  When runserver restarts itself, it closes its port, but sass continues to listen there, causing address already in use errors in runserver:

```
Error: [Errno 48] Address already in use
```

```
(default)cmason:code cmason$ lsof -i :8000 | grep ruby 
ruby      97338 cmason   16u  IPv4 0xb475ce6f58cb6cfd      0t0  TCP *:irdmi (LISTEN)
```

We add the `close_fds` argument to `Popen` and this fixes the issue.
