### PR TITLE
altered directory ignoring option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,19 @@ If you want to, for example, use Compass with Sass, use:
 You can also define patterns (files or directories) for Civet to ignore by
 setting:
 
-    CIVET_IGNORE = ['bower_components', 'node_modules']
+    # As an exmaple, this will cause Civet to ignore files with 'coffee' in the
+    # name or path.
+    CIVET_IGNORE_PATTERNS = ['coffee']
 
 This gets extended into the ignore_patterns list defined in
 `django.contrib.staticfiles.management.commands.collectstatic`.
+
+You can also define staticfile directories you want Civet to ignore by setting:
+
+    # This will cause Civet to ignore files located in 'bower_components' or
+    # 'node_modules' even if those folders are included in STATICFILES_DIRS.
+    CIVET_IGNORE_DIRS = ['bower_components', 'node_modules']
+
 
 This is particularly useful when using a package manager such as [Bower](http://bower.io/)
 or [NPM](https://www.npmjs.com/).  These managers often install packages that

--- a/civet/asset_precompiler.py
+++ b/civet/asset_precompiler.py
@@ -57,8 +57,10 @@ sass_bin = getattr(
     settings, 'CIVET_SASS_BIN', 'sass')
 
 additional_ignore_patterns = getattr(
-    settings, 'CIVET_IGNORE', None)
+    settings, 'CIVET_IGNORE_PATTERNS', None)
 
+ignore_dirs = getattr(
+    settings, 'CIVET_IGNORE_DIRS', [])
 
 def precompile_and_watch_coffee_and_sass_assets():
     thread.start_new_thread(
@@ -494,6 +496,7 @@ def collect_coffee_and_sass_files():
     # one for the /static directories of the apps listed in INSTALLED_APPS.
     # This allows us to discover all the files we are interested in across
     # the entire project, including the libraries it uses.
+
     for finder in finders.get_finders():
         for partial_path, storage in finder.list(ignore_patterns):
             # Get the actual path of the asset
@@ -503,9 +506,13 @@ def collect_coffee_and_sass_files():
             src_path = os.path.realpath(full_path)
 
             base, ext = os.path.splitext(partial_path)
-            if ext == '.coffee':
-                coffee_files.append((src_path, get_output_path(base, '.js')))
-            elif ext == '.scss' or ext == '.sass':
-                sass_files.append((src_path, get_output_path(base, '.css')))
+
+            if not any(dirs in full_path for dirs in ignore_dirs):
+                if ext == '.coffee':
+                    coffee_files.append((src_path,
+                                        get_output_path(base, '.js')))
+                elif ext == '.scss' or ext == '.sass':
+                    sass_files.append((src_path,
+                                      get_output_path(base, '.css')))
 
     return coffee_files, sass_files

--- a/civet/asset_precompiler.py
+++ b/civet/asset_precompiler.py
@@ -62,6 +62,7 @@ additional_ignore_patterns = getattr(
 ignore_dirs = getattr(
     settings, 'CIVET_IGNORE_DIRS', [])
 
+
 def precompile_and_watch_coffee_and_sass_assets():
     thread.start_new_thread(
         precompile_coffee_and_sass_assets, (), {
@@ -484,7 +485,7 @@ def collect_coffee_and_sass_files():
     ignore_patterns = ['CVS', '.*', '*~']
 
     if additional_ignore_patterns:
-      ignore_patterns.extend(additional_ignore_patterns)
+        ignore_patterns.extend(additional_ignore_patterns)
 
     def get_output_path(base, ext):
         return os.path.join(precompiled_assets_dir, base + ext)

--- a/testsite/.bowerrc
+++ b/testsite/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "static/bower_components"
-}

--- a/testsite/foo/templates/index.html
+++ b/testsite/foo/templates/index.html
@@ -16,14 +16,14 @@
     in `to_be_ignored` and the more deeply nested 'bower_components/test/test_Styles' dir,
     which are specified in CIVET_IGNORE (settings.py).
     -->
-    <link rel="stylesheet" href="{% static 'to_be_ignored/test.css' %}">
+    <link rel="stylesheet" href="{% static 'test.css' %}">
 
     <!--
     this will not produce an error, per se, but if you inspect main.scss and its import,
     _sass_partial.scss, you'll notice that .foo should display {color: blue;}.  That it does
     not is further proof that these files are ignored by Civet.
      -->
-    <link rel="stylesheet" href="{% static 'bower_components/test/test_styles/main.css' %}">
+    <link rel="stylesheet" href="{% static 'test/test_styles/main.css' %}">
 
     <!-- should be found -->
     <script src="{% static 'js/global.js' %}" async defer></script>
@@ -37,7 +37,7 @@
     The purpose of this is to demonstrate that civet is properly ignoring files
     in `to_be_ignored`, which is specified in CIVET_IGNORE (settings.py)
     -->
-    <script src="{% static 'to_be_ignored/random.js' %}" async defer></script>
+    <script src="{% static 'random.js' %}" async defer></script>
 </head>
 <body>
 

--- a/testsite/myapp/settings.py
+++ b/testsite/myapp/settings.py
@@ -116,7 +116,6 @@ INSTALLED_APPS = (
 )
 
 CIVET_SASS_ARGUMENTS = ('--compass', )
-CIVET_IGNORE_PATTERNS = ['']
 CIVET_IGNORE_DIRS = ['bower_components', 'to_be_ignored']
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'

--- a/testsite/myapp/settings.py
+++ b/testsite/myapp/settings.py
@@ -68,6 +68,7 @@ STATICFILES_DIRS = (
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
     os.path.join(BASE_DIR, "static"),
+    os.path.join(BASE_DIR, "bower_components"),
 )
 
 # List of finder classes that know how to find static files in
@@ -115,7 +116,8 @@ INSTALLED_APPS = (
 )
 
 CIVET_SASS_ARGUMENTS = ('--compass', )
-CIVET_IGNORE = ['bower_components', 'to_be_ignored']
+CIVET_IGNORE_PATTERNS = ['']
+CIVET_IGNORE_DIRS = ['bower_components', 'to_be_ignored']
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 


### PR DESCRIPTION
Hey @lukhnos!

Turns out the previous PR (extending `ignore_patterns`) needs to be improved.  The new use case is:

- Suppose bower or npm install to the project root.  
- `bower_components` and `node_modules` are added to `STATICFILES_DIRS`
- Project structure like follows:

```
testsite
|__ bower_components/
|__ node_modules/
|__ foo/
    |__ static/
    |__ templates/
    |__ __init__.py
    |__ etc...
|__ myapp/
    |__ settings.py
    |__ etc...
|__ precompiled_assets/
|__ static/
    |__ etc...

```

We need to be able to tell `Civet` to ignore files located in these dirs (for the same reasons as before).  I added a conditional before the file extension check in `collect_coffee_and_sass_files()`
```python
if not any(dirs in full_path for dirs in ignore_dirs):
    if ext == '.coffee':
        coffee_files.append((src_path, get_output_path(base, '.js')))
    elif ext == '.scss' or ext == '.sass':
        sass_files.append((src_path, get_output_path(base, '.css')))
```
Extending `ignore_patterns` unfortunately wasn't enough as `finder.list(ignore_patterns)`
returns a relative path (and storage instance), relative to the directories listed in `STATICFILES_DIRS`.  This means that any excluded directory names wouldn't actually be contained in `partial_path`.