### PR TITLE
Add instructions for using civet with Django 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ In Django 1.6 and before, add it right after
 `django.contrib.staticfiles`. In Django 1.7 and later, add it
 before `django.contrib.staticfiles`:
 
-    INSTALLED_APPS = (
-        # ...
-        # 'civet',  # Uncomment for Django 1.7 and later
-        'django.contrib.staticfiles',
-        # 'civet',  # Uncomment for Django 1.6 and later
-        # ...
-    )
+```python
+INSTALLED_APPS = (
+    # ...
+    # 'civet',  # Uncomment for Django 1.7 and later
+    'django.contrib.staticfiles',
+    # 'civet',  # Uncomment for Django 1.6 and later
+    # ...
+)
+```
 
 Then add a `CIVET_PRECOMPILED_ASSET_DIR` setting that tells Civet where to
 put the precompiled assets. For example:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ INSTALLED_APPS = (
     # ...
     # 'civet',  # Uncomment for Django 1.7 and later
     'django.contrib.staticfiles',
-    # 'civet',  # Uncomment for Django 1.6 and later
+    # 'civet',  # Uncomment for Django 1.6 and earlier
     # ...
 )
 ```

--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ app server when you make changes to your Python source code
 Usage
 -----
 
-In your `settings.py`, add Civet to your `INSTALLED_APPS` right after
-`django.contrib.staticfiles`:
+In your `settings.py`, add Civet to your `INSTALLED_APPS` setting.
+In Django 1.6 and before, add it right after
+`django.contrib.staticfiles`. In Django 1.7 and later, add it
+before `django.contrib.staticfiles`:
 
     INSTALLED_APPS = (
         # ...
+        # 'civet',  # Uncomment for Django 1.7 and later
         'django.contrib.staticfiles',
-        'civet',
+        # 'civet',  # Uncomment for Django 1.6 and later
         # ...
     )
 


### PR DESCRIPTION
This PR updates the README instructions to cover the change in the order in which management commands are loaded in Django 1.7. Django 1.6 loaded management commands from `INSTALLED_APPS` [in the order in which they were listed](https://github.com/django/django/blob/1.6/django/core/management/__init__.py#L104-L118). However, Django 1.7 [changed this](https://github.com/django/django/blob/d92b08536d873c0966e8192e64d8e8bd9de79ebe/django/core/management/__init__.py#L73-L75) and loads management commands in reverse order.

This means that we civet needs to be listed _before_ `django.contrib.staticfiles` so that civet's `runserver` overrides staticfiles in Django 1.7.