### PR TITLE
decode the stdout so a textual regex can scan it.

### DIFF
--- a/civet/compilers/sass.py
+++ b/civet/compilers/sass.py
@@ -62,6 +62,7 @@ class SassCompiler(Compiler):
             env['BUNDLE_GEMFILE'] = bundle_gemfile
             process = subprocess.Popen(args, stdout=subprocess.PIPE, env=env)
             stdout, _ = process.communicate()
+            stdout = stdout.decode(sys.getdefaultencoding(), errors='ignore')
 
             if process.returncode != 0:
                 lines = stdout.split('\n')


### PR DESCRIPTION
@masoncj This fixes an error seen on Python 3, where a textual regex was being used to scan a bytestring:
```
  File "/Users/lucaswiman/opensource/civet/civet/asset_precompiler.py", line 81, in precompile_assets
    compilers.append(compiler_class(precompiled_assets_dir, kill_on_error))
  File "/Users/lucaswiman/opensource/civet/civet/compilers/sass.py", line 74, in __init__
    match = BUNDLE_LIST_SASS_FINDER.search(stdout)
TypeError: cannot use a string pattern on a bytes-like object
```